### PR TITLE
Version1 메인 상단 기본 배너 케러셸 구현 완료 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "http-proxy-middleware": "^1.0.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-responsive-carousel": "^3.2.5",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1"
   },

--- a/client/src/components/Banner.jsx
+++ b/client/src/components/Banner.jsx
@@ -1,9 +1,40 @@
 /** @format */
 
 import React from "react";
+import { Carousel } from 'react-responsive-carousel';
+import "react-responsive-carousel/lib/styles/carousel.min.css";
 
 function Banner() {
-  return <div>그리다 소개 및 사용법</div>;
+  return (
+    <div className='banner'>
+      <Carousel className='banner__carousel'
+        autoPlay
+        infiniteLoop
+        showThumbs={false}
+        stopOnHover
+        dynamicHeight
+      >
+        <div>
+          <img src="https://cdn.pixabay.com/photo/2020/04/30/20/51/flower-5114574_960_720.jpg"
+            height="300"
+          />
+          <p className="legend">소개 1</p>
+        </div>
+        <div>
+          <img src="https://cdn.pixabay.com/photo/2014/12/04/14/46/magnolia-trees-556718_960_720.jpg"
+            height="300"
+          />
+          <p className="legend">소개 2</p>
+        </div>
+        <div>
+          <img src="https://cdn.pixabay.com/photo/2014/02/27/16/10/spring-276014_960_720.jpg"
+            height="300"
+          />
+          <p className="legend">소개 3</p>
+        </div>
+      </Carousel>
+    </div>
+  );
 }
 
 export default Banner;

--- a/client/src/style/components/banner.css
+++ b/client/src/style/components/banner.css
@@ -1,0 +1,7 @@
+/** @format */
+
+.banner {
+  width: 80%;
+  display: flex;
+  align-items: center;
+}

--- a/client/src/style/styles.css
+++ b/client/src/style/styles.css
@@ -4,3 +4,4 @@
 @import "main.css";
 @import "./components/header.css";
 @import "./components/search.css";
+@import "./components/banner.css";


### PR DESCRIPTION
## Summary <!-- Type "It closes #0000" to automatically close the issue -->
It closes #21 .

배너 케러셸에 대한 구현은 일단은 완료하였습니다.
이미 구현되어있는 라이브러리를 활용하였습니다.

https://www.npmjs.com/package/react-responsive-carousel

부족한 부분은 아래  Further Work의 이슈를 통해 적어두었습니다.

## Screenshots <!-- Please add any screenshots or video for a quicker review process -->

![May-05-2020 13-44-35](https://user-images.githubusercontent.com/18658656/81035598-98726200-8ed6-11ea-9f64-84ac3cb0d4c0.gif)


## Further Work <!-- It's a good to make a PR smaller. Please paste the link of new issue here -->
#27


